### PR TITLE
Feat/post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,8 @@
 webserv
 *.conf
 
-www/usrimg/imag*
+www/usrimg/*
+!www/usrimg/no-bedbugs.jpg
 
 __pycache__
 env

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VPATH			:= ./utils/ ./server/ ./exceptions/
 
 SRC				:= main.cpp
 
-UTILS_SRC		:=
+UTILS_SRC		:= utils1.cpp
 
 SERVER_SRC		:= Server.cpp Request.cpp
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 NAME			:= webserv
 CPP				:= c++
-CPPFLAGS		:= -Wall -Wextra -Werror
+CPPFLAGS		:= -Wall -Wextra -Werror -std=c++17
 
 # ---------------------------------------------------------------------------- #
 #                                     Files                                    #

--- a/exceptions/Exception_server.cpp
+++ b/exceptions/Exception_server.cpp
@@ -4,7 +4,7 @@ BaseException::BaseException(const std::string& msg) : message(msg)
 {
 }
 
-const char* BaseException::what() const noexcept
+const char* BaseException::what() const NOEXCEPT_SPEC
 {
 	return message.c_str();
 }

--- a/exceptions/Exceptions.hpp
+++ b/exceptions/Exceptions.hpp
@@ -3,13 +3,19 @@
 
 # include "../webserv.h"
 
+# ifdef __APPLE__
+#  define NOEXCEPT_SPEC _NOEXCEPT
+# else
+#  define NOEXCEPT_SPEC noexcept
+# endif
+
 class BaseException : public std::exception
 {
 	protected:
 		std::string			message;
 	public:
 		explicit			BaseException(const std::string& msg);
-		virtual const char*	what() const noexcept override;
+		virtual const char*	what() const NOEXCEPT_SPEC override;
 };
 
 class InvalidIPAddressException : public BaseException

--- a/main.cpp
+++ b/main.cpp
@@ -17,8 +17,8 @@ int main()
 	try
 	{
 		std::signal(SIGINT, signal_handler);
-		// Server	server1("A little webserver", PORT, "0.0.0.0", "index.html", "usrimg", "www");
-		Server	server1("A Instagram Knockoff", PORT, "0.0.0.0", "index.html", "images", "image_website");
+		Server	server1("A little webserver", PORT, "0.0.0.0", "index.html", "usrimg", "www");
+		// Server	server1("A Instagram Knockoff", PORT, "0.0.0.0", "index.html", "images", "image_website");
 		// Set response Method is outdated since the server is using the file system in dir /www/
 		server1.setResponse("HTTP/1.1 200 OK\nContent-Type: text/html\n\nA surprise to be sure, but a welcome one!\n");
 

--- a/main.cpp
+++ b/main.cpp
@@ -17,8 +17,8 @@ int main()
 	try
 	{
 		std::signal(SIGINT, signal_handler);
-		Server	server1("A little webserver", PORT, "0.0.0.0", "index.html", "usrimg", "www");
-		// Server	server1("A Instagram Knockoff", PORT, "0.0.0.0", "index.html", "images", "image_website");
+		// Server	server1("A little webserver", PORT, "0.0.0.0", "index.html", "usrimg", "www");
+		Server	server1("A Instagram Knockoff", PORT, "0.0.0.0", "index.html", "images", "image_website");
 		// Set response Method is outdated since the server is using the file system in dir /www/
 		server1.setResponse("HTTP/1.1 200 OK\nContent-Type: text/html\n\nA surprise to be sure, but a welcome one!\n");
 
@@ -71,7 +71,6 @@ int main()
 			{
 				if (fds[i].fd != -1 && (fds[i].revents & POLLIN))
 				{
-					std::cout << "I AM HERE MOTHERF\n";
 					std::vector<char>	accumulated_request;
 					std::vector<char>	buffer(4096);
 					size_t				content_len = 0;
@@ -105,22 +104,28 @@ int main()
 								header_parsed = true;
 								std::string	headers = temp_request.substr(0, header_end + 4);
 								size_t content_len_pos = headers.find("Content-Length: ");
+								std::cout << "Headers:\n" << headers << std::endl;
 								if (content_len_pos != std::string::npos)
 								{
 									size_t content_length_start = content_len_pos + 16;
 									size_t content_length_end = headers.find("\r\n", content_length_start);
 									std::string content_length_str = headers.substr(content_length_start, content_length_end - content_length_start);
 									content_len = std::stoul(content_length_str);
+									// std::cout << "|TEMPREQUESTBEGIN:\n\n\n|" << temp_request << "|TEMPREQUESTEND\n\n\n|" << std::endl;
 								}
 								body_bytes_read = temp_request.size() - (header_end + 4);
 							}
 						}
-
+						// std::cout << "Body Bytes Read: " << body_bytes_read << std::endl;
 						if (header_parsed && content_len > 0)
 						{
 							if (body_bytes_read >= content_len)
 								break ;
 						}
+						if (header_parsed && content_len == 0)
+								break ;
+						if (header_parsed)
+							body_bytes_read += bytes_read;
 					}
 					if (header_parsed && (content_len == 0 || body_bytes_read >= content_len))
 					{

--- a/main.cpp
+++ b/main.cpp
@@ -95,6 +95,7 @@ int main()
 						std::string temp_request(accumulated_request.begin(), accumulated_request.end());
 						if (temp_request.find("\r\n\r\n") != std::string::npos)
 						{
+							// std::cout << "Request:\n\n" << std::string(accumulated_request.begin(), accumulated_request.end()) << std::endl;
 							Request req(std::string(accumulated_request.begin(), accumulated_request.end()), fds[i].fd);
 							server1.process_request(req);
 							accumulated_request.clear();

--- a/main.cpp
+++ b/main.cpp
@@ -66,41 +66,28 @@ int main()
 					}
 				}
 			}
+			//sends data do available clients
 			for (int i = 1; i < nfds; i++)
 			{
 				if (fds[i].fd != -1 && (fds[i].revents & POLLIN))
 				{
-					std::string	accumulated_request;
-					char		buffer[4096] = {0};
-					while (true)
-					{
-						int		bytes_read = read(fds[i].fd, buffer, sizeof(buffer) - 1);
+					char	buffer[4096] = {0};
+					int		bytes_read = read(fds[i].fd, buffer, 4096);
 
-						if (bytes_read < 0)
-						{
-							std::cerr << "Error reading from fd " << fds[i].fd << std::endl;
-							close(fds[i].fd);
-							fds[i].fd = -1;
-							break;
-						}
-						if (bytes_read == 0)
-						{
-							std::cout << "Client on fd " << fds[i].fd << " disconnected" << std::endl;
-							close(fds[i].fd);
-							fds[i].fd = -1;
-							break;
-						}
-						accumulated_request.append(buffer, bytes_read);
-						if (accumulated_request.find("\r\n\r\n") != std::string::npos)
-						{
-							std::cout << "Full Request Received: " << accumulated_request << std::endl;
-							Request req(accumulated_request, fds[i].fd);
-							server1.process_request(req);
-							accumulated_request.clear();
-							close(fds[i].fd);
-							fds[i].fd = -1;
-							break;
-						}
+					if (bytes_read <= 0)
+					{
+						std::cout << "Client on fd " << fds[i].fd << " disconnected" << std::endl;
+						close(fds[i].fd);
+						fds[i].fd = -1;
+					}
+					else
+					{
+						std::string	request(buffer);
+						std::cout << request << std::endl;
+						Request	req(buffer, fds[i].fd);
+						server1.process_request(req);
+						close(fds[i].fd);
+						fds[i].fd = -1;
 					}
 				}
 			}

--- a/main.cpp
+++ b/main.cpp
@@ -66,28 +66,41 @@ int main()
 					}
 				}
 			}
-			//sends data do available clients
 			for (int i = 1; i < nfds; i++)
 			{
 				if (fds[i].fd != -1 && (fds[i].revents & POLLIN))
 				{
-					char	buffer[4096] = {0};
-					int		bytes_read = read(fds[i].fd, buffer, 4096);
+					std::string	accumulated_request;
+					char		buffer[4096] = {0};
+					while (true)
+					{
+						int		bytes_read = read(fds[i].fd, buffer, sizeof(buffer) - 1);
 
-					if (bytes_read <= 0)
-					{
-						std::cout << "Client on fd " << fds[i].fd << " disconnected" << std::endl;
-						close(fds[i].fd);
-						fds[i].fd = -1;
-					}
-					else
-					{
-						std::string	request(buffer);
-						std::cout << request << std::endl;
-						Request	req(buffer, fds[i].fd);
-						server1.process_request(req);
-						close(fds[i].fd);
-						fds[i].fd = -1;
+						if (bytes_read < 0)
+						{
+							std::cerr << "Error reading from fd " << fds[i].fd << std::endl;
+							close(fds[i].fd);
+							fds[i].fd = -1;
+							break;
+						}
+						if (bytes_read == 0)
+						{
+							std::cout << "Client on fd " << fds[i].fd << " disconnected" << std::endl;
+							close(fds[i].fd);
+							fds[i].fd = -1;
+							break;
+						}
+						accumulated_request.append(buffer, bytes_read);
+						if (accumulated_request.find("\r\n\r\n") != std::string::npos)
+						{
+							std::cout << "Full Request Received: " << accumulated_request << std::endl;
+							Request req(accumulated_request, fds[i].fd);
+							server1.process_request(req);
+							accumulated_request.clear();
+							close(fds[i].fd);
+							fds[i].fd = -1;
+							break;
+						}
 					}
 				}
 			}

--- a/server/Request.cpp
+++ b/server/Request.cpp
@@ -61,22 +61,41 @@ Request&	Request::operator=(const Request &copy)
 /*                                  Functions                                 */
 /* -------------------------------------------------------------------------- */
 
-std::vector<std::string> tokenize(const std::string& str, const std::string& delim) {
-    std::vector<std::string> tokens;
-    size_t start = 0;
-    size_t end = str.find(delim);
-    
-    while (end != std::string::npos) {
-        tokens.push_back(str.substr(start, end - start));
-        start = end + 1;
-        end = str.find(delim, start);
-    }
-    
-    tokens.push_back(str.substr(start));
-    
-    return tokens;
-}
+void	Request::fill_string_to_map(std::string input)
+{
+			std::istringstream	ss(input);
+			std::string			line;
+			size_t				line_count = 0;
+			std::string			file_name;
+			std::string			file_content;
+			size_t				pos;
 
+			while (std::getline(ss, line))
+			{
+				if (line_count == 0)
+				{
+					line_count++;
+					continue;
+				}
+				if (line_count == 1)
+				{
+					pos = line.find("filename=\"");
+					if (pos == std::string::npos)
+						file_name = "unknown";
+					else
+						file_name = line.substr(pos + 10, line.length() - (pos + 10) - 2);
+					line_count++;
+					continue;
+				}
+				if (line_count == 2 || line_count == 3)
+				{
+					line_count++;
+					continue;
+				}
+				file_content += line + "\n";
+			}
+			_post_files[file_name] = file_content;
+}
 
 int	Request::process_post(const std::string& request)
 {
@@ -103,64 +122,14 @@ int	Request::process_post(const std::string& request)
 	if (con_type == "multipart/form-data")
 	{
 		std::string	boundary = "--" + line.substr(end + 12);
-		std::cout << "Boundary = " + boundary << std::endl;
 		std::vector<std::string>	temp = tokenize(request, boundary);
 		for (size_t i = 1; i < temp.size(); ++i)
 		{
-			std::istringstream	ss(temp[i]);
-			std::string			line2;
-			size_t				line_count = 0;
-			std::string			file_name;
-			std::string			file_content;
-
-			while (std::getline(ss, line2))
-			{
-				if (line_count == 0)
-				{
-					line_count++;
-					continue;
-				}
-				if (line_count == 1)
-				{
-					pos = line2.find("filename=\"");
-					if (pos == std::string::npos)
-						file_name = "unknown";
-					else
-						file_name = line2.substr(pos + 10, line2.length() - (pos + 10) - 2);
-					line_count++;
-					continue;
-				}
-				if (line_count == 2 || line_count == 3)
-				{
-					line_count++;
-					continue;
-				}
-				file_content += line2 + "\n";
-			}
-			_post_files[file_name] = file_content;
+			fill_string_to_map(temp[i]);
 		}
 	}
 	return (0);
 }
-
-// void	Server::load_mime_types(const std::string& file_path)
-// {
-// 	std::ifstream file(file_path);
-// 	if (!file.is_open())
-// 		throw OpenFailedException(_name, file_path);
-// 	std::string	line;
-// 	while(std::getline(file, line))
-// 	{
-// 		std::istringstream	ss(line);
-// 		std::string			extension;
-// 		std::string			mime_type;
-
-// 		if (std::getline(ss, extension, '\t') && std::getline(ss, mime_type))
-// 			_mime_types[extension] = mime_type;
-// 	}
-// 	file.close();
-// }
-
 
 /* -------------------------------------------------------------------------- */
 /*                                Getter/Setter                               */

--- a/server/Request.cpp
+++ b/server/Request.cpp
@@ -17,7 +17,8 @@ Request::Request(const std::string& request, int fd)
 	else if (request.compare(0, 4, "POST") == 0)
 	{
 		_method = POST;
-		//! Add an extraction for _content_type
+		if (process_post(request) == 1)
+			std::cout << "RETURNED 1\n";
 		method = request.find("POST ") + 5;
 	}
 	else if (request.compare(0, 6, "DELETE") == 0)
@@ -59,6 +60,56 @@ Request&	Request::operator=(const Request &copy)
 /* -------------------------------------------------------------------------- */
 /*                                  Functions                                 */
 /* -------------------------------------------------------------------------- */
+
+int	Request::process_post(const std::string& request)
+{
+	std::istringstream	stream(request);
+	std::string			line;
+	std::string			last_line;
+	size_t				pos;
+
+	while (std::getline(stream, line))
+	{
+		// std::cout << "LINE: " + line << std::endl;
+		pos = line.find("Content-Type: ");
+		if (pos != std::string::npos)
+			break ;
+	}
+	if (!std::getline(stream, last_line))
+		return (1);
+	size_t	end = line.find(';');
+	if (end == std::string::npos)
+		return (1);
+	pos += 14;
+	std::string	con_type = line.substr(pos, end - pos);
+	_content_type = con_type;
+	// std::cout << "CONTENT typE: " + con_type << std::endl;
+	if (con_type == "multipart/form-data")
+	{
+		std::string	boundary = line.substr(end + 12);
+		std::cout << "Boundary = " + boundary << std::endl;
+	}
+	return (0);
+}
+
+// void	Server::load_mime_types(const std::string& file_path)
+// {
+// 	std::ifstream file(file_path);
+// 	if (!file.is_open())
+// 		throw OpenFailedException(_name, file_path);
+// 	std::string	line;
+// 	while(std::getline(file, line))
+// 	{
+// 		std::istringstream	ss(line);
+// 		std::string			extension;
+// 		std::string			mime_type;
+
+// 		if (std::getline(ss, extension, '\t') && std::getline(ss, mime_type))
+// 			_mime_types[extension] = mime_type;
+// 	}
+// 	file.close();
+// }
+
 
 /* -------------------------------------------------------------------------- */
 /*                                Getter/Setter                               */

--- a/server/Request.cpp
+++ b/server/Request.cpp
@@ -75,7 +75,7 @@ int	Request::process_post(const std::string& request)
 		if (pos != std::string::npos)
 			break ;
 	}
-	if (line.empty() || !std::getline(stream, last_line))
+	if (!std::getline(stream, last_line))
 		return (1);
 	size_t	end = line.find(';');
 	if (end == std::string::npos)
@@ -83,40 +83,11 @@ int	Request::process_post(const std::string& request)
 	pos += 14;
 	std::string	con_type = line.substr(pos, end - pos);
 	_content_type = con_type;
-	std::cout << "CONTENT typE: " + con_type << std::endl;
+	// std::cout << "CONTENT typE: " + con_type << std::endl;
 	if (con_type == "multipart/form-data")
 	{
-		std::string	boundary = "--" + line.substr(end + 12);
-		// std::cout << "Boundary = " + boundary << std::endl;
-		std::istringstream	stream2(request);
-		while (std::getline(stream2, line) && line != "\r") {}
-		while (std::getline(stream2, line))
-		{
-			if (line.find(boundary) != std::string::npos)
-			{
-				if (last_line.find(boundary) != std::string::npos)
-					break;
-			}
-				std::string file_name;
-				std::getline(stream2, line);
-				pos = line.find("filename=\"");
-				if (pos == std::string::npos)
-					file_name = "unknown";
-				else
-					file_name = line.substr(pos + 10, line.length() - (pos + 10) - 2);
-				std::cout << "filename: " + file_name << "|" << std::endl;
-				std::getline(stream2, line);
-				std::getline(stream2, line);
-				std::string content;
-				while (std::getline(stream2, line))
-				{
-					if (line.find(boundary) != std::string::npos)
-						break;
-					content += line + "\n";
-				}
-			_post_files[file_name] = content; 
-		}
-		last_line = line;
+		std::string	boundary = line.substr(end + 12);
+		std::cout << "Boundary = " + boundary << std::endl;
 	}
 	return (0);
 }

--- a/server/Request.cpp
+++ b/server/Request.cpp
@@ -100,13 +100,11 @@ int	Request::process_post(const std::string& request)
 	pos += 14;
 	std::string	con_type = line.substr(pos, end - pos);
 	_content_type = con_type;
-	std::cout << "CONTENT typE: " + con_type << std::endl;
 	if (con_type == "multipart/form-data")
 	{
 		std::string	boundary = "--" + line.substr(end + 12);
 		std::cout << "Boundary = " + boundary << std::endl;
 		std::vector<std::string>	temp = tokenize(request, boundary);
-		// for (const auto& str : temp) std::cout << "NEW PART:\n\n\n|" << str << std::endl;
 		for (size_t i = 1; i < temp.size(); ++i)
 		{
 			std::istringstream	ss(temp[i]);
@@ -115,7 +113,6 @@ int	Request::process_post(const std::string& request)
 			std::string			file_name;
 			std::string			file_content;
 
-			// std::cout << "NEW PART:\n\n\n|" << temp[i] << std::endl;
 			while (std::getline(ss, line2))
 			{
 				if (line_count == 0)

--- a/server/Request.cpp
+++ b/server/Request.cpp
@@ -75,7 +75,7 @@ int	Request::process_post(const std::string& request)
 		if (pos != std::string::npos)
 			break ;
 	}
-	if (!std::getline(stream, last_line))
+	if (line.empty() || !std::getline(stream, last_line))
 		return (1);
 	size_t	end = line.find(';');
 	if (end == std::string::npos)
@@ -83,11 +83,40 @@ int	Request::process_post(const std::string& request)
 	pos += 14;
 	std::string	con_type = line.substr(pos, end - pos);
 	_content_type = con_type;
-	// std::cout << "CONTENT typE: " + con_type << std::endl;
+	std::cout << "CONTENT typE: " + con_type << std::endl;
 	if (con_type == "multipart/form-data")
 	{
-		std::string	boundary = line.substr(end + 12);
-		std::cout << "Boundary = " + boundary << std::endl;
+		std::string	boundary = "--" + line.substr(end + 12);
+		// std::cout << "Boundary = " + boundary << std::endl;
+		std::istringstream	stream2(request);
+		while (std::getline(stream2, line) && line != "\r") {}
+		while (std::getline(stream2, line))
+		{
+			if (line.find(boundary) != std::string::npos)
+			{
+				if (last_line.find(boundary) != std::string::npos)
+					break;
+			}
+				std::string file_name;
+				std::getline(stream2, line);
+				pos = line.find("filename=\"");
+				if (pos == std::string::npos)
+					file_name = "unknown";
+				else
+					file_name = line.substr(pos + 10, line.length() - (pos + 10) - 2);
+				std::cout << "filename: " + file_name << "|" << std::endl;
+				std::getline(stream2, line);
+				std::getline(stream2, line);
+				std::string content;
+				while (std::getline(stream2, line))
+				{
+					if (line.find(boundary) != std::string::npos)
+						break;
+					content += line + "\n";
+				}
+			_post_files[file_name] = content; 
+		}
+		last_line = line;
 	}
 	return (0);
 }

--- a/server/Request.hpp
+++ b/server/Request.hpp
@@ -23,9 +23,9 @@ class Request
 		int			_fd;
 		std::string	_file_path;
 		std::string	_content_type;
-		std::unordered_map<std::string, std::string> _post_files;
 		int			process_post(const std::string& request);
 	public:
+		std::unordered_map<std::string, std::string> _post_files;
 		Request(const std::string& request, int fd);
 		~Request();
 		Request(const Request& copy);

--- a/server/Request.hpp
+++ b/server/Request.hpp
@@ -12,7 +12,7 @@
 # endif /*POST*/
 
 # ifndef DELETE
-#  define DELETE 1
+#  define DELETE 2
 # endif /*DELETE*/
 
 /// @brief Takes the request from a client and parses it.
@@ -23,6 +23,8 @@ class Request
 		int			_fd;
 		std::string	_file_path;
 		std::string	_content_type;
+		std::unordered_map<std::string, std::string> _post_files;
+		int			process_post(const std::string& request);
 	public:
 		Request(const std::string& request, int fd);
 		~Request();

--- a/server/Request.hpp
+++ b/server/Request.hpp
@@ -23,9 +23,9 @@ class Request
 		int			_fd;
 		std::string	_file_path;
 		std::string	_content_type;
+		std::unordered_map<std::string, std::string> _post_files;
 		int			process_post(const std::string& request);
 	public:
-		std::unordered_map<std::string, std::string> _post_files;
 		Request(const std::string& request, int fd);
 		~Request();
 		Request(const Request& copy);

--- a/server/Request.hpp
+++ b/server/Request.hpp
@@ -24,6 +24,7 @@ class Request
 		std::string	_file_path;
 		std::string	_content_type;
 		int			process_post(const std::string& request);
+		void		fill_string_to_map(std::string input);
 	public:
 		std::unordered_map<std::string, std::string> _post_files;
 		Request(const std::string& request, int fd);

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -168,9 +168,9 @@ int	Server::process_request(const Request& req)
 		case DELETE:
 			return (process_delete(req));
 			break;
-		// case POST:
-		// 	return (process_post(req))<
-		// 	break;
+		case POST:
+			return (process_post(req));
+			break;
 	}
 	return (1);
 }
@@ -216,10 +216,33 @@ int	Server::process_delete(const Request& req)
 	return (0);
 }
 
-// int	Server::process_post(const Request& req)
-// {
-	
-// }
+int	Server::process_post(const Request& req)
+{
+	std::cout << "I AM HERE" << std::endl;
+	long unsigned int	failed = 0;
+	for (const auto& entry : req._post_files)
+	{
+		const std::string&	file_name = entry.first;
+		const std::string&	content = entry.second;
+		std::string			full_path = _www_dir + "/" + _data_dir + "/" +file_name;
+		std::ofstream out_file(full_path, std::ios::binary);
+		if (!out_file)
+		{
+			failed++;
+	std::cout << "I AM HERE2222" << std::endl;
+			continue;
+		}
+		out_file << content;
+		// out_file.write(content.c_str(), content.size()); 
+		out_file.close();
+	}
+	if (failed == req._post_files.size())
+		send_error_message(500, req);
+	if (failed > 0)
+		send_error_message(207, req);
+	send_error_message(200, req);
+	return (0);
+}
 
 int	Server::send_error_message(int error_code, const Request& req)
 {

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -168,9 +168,9 @@ int	Server::process_request(const Request& req)
 		case DELETE:
 			return (process_delete(req));
 			break;
-		// case POST:
-		// 	return (process_post(req))<
-		// 	break;
+		case POST:
+			return (process_post(req));
+			break;
 	}
 	return (1);
 }
@@ -216,10 +216,34 @@ int	Server::process_delete(const Request& req)
 	return (0);
 }
 
-// int	Server::process_post(const Request& req)
-// {
-	
-// }
+int	Server::process_post(const Request& req)
+{
+	std::cout << "I AM HERE" << std::endl;
+	long unsigned int	failed = 0;
+	for (const auto& entry : req._post_files)
+	{
+		const std::string&	file_name = entry.first;
+		const std::string&	content = entry.second;
+		std::string			full_path = _www_dir + "/" + _data_dir + "/" +file_name;
+		std::ofstream out_file(full_path, std::ios::binary);
+		if (!out_file)
+		{
+			failed++;
+	std::cout << "I AM HERE2222" << std::endl;
+			continue;
+		}
+		out_file << content;
+		// out_file.write(content.c_str(), content.size()); 
+		out_file.close();
+	}
+	if (failed == req._post_files.size())
+		send_error_message(500, req);
+	if (failed > 0)
+		send_error_message(207, req);
+	send_error_message(200, req);
+	return (0);
+}
+
 
 int	Server::send_error_message(int error_code, const Request& req)
 {

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -168,9 +168,9 @@ int	Server::process_request(const Request& req)
 		case DELETE:
 			return (process_delete(req));
 			break;
-		case POST:
-			return (process_post(req));
-			break;
+		// case POST:
+		// 	return (process_post(req))<
+		// 	break;
 	}
 	return (1);
 }
@@ -216,33 +216,10 @@ int	Server::process_delete(const Request& req)
 	return (0);
 }
 
-int	Server::process_post(const Request& req)
-{
-	std::cout << "I AM HERE" << std::endl;
-	long unsigned int	failed = 0;
-	for (const auto& entry : req._post_files)
-	{
-		const std::string&	file_name = entry.first;
-		const std::string&	content = entry.second;
-		std::string			full_path = _www_dir + "/" + _data_dir + "/" +file_name;
-		std::ofstream out_file(full_path, std::ios::binary);
-		if (!out_file)
-		{
-			failed++;
-	std::cout << "I AM HERE2222" << std::endl;
-			continue;
-		}
-		out_file << content;
-		// out_file.write(content.c_str(), content.size()); 
-		out_file.close();
-	}
-	if (failed == req._post_files.size())
-		send_error_message(500, req);
-	if (failed > 0)
-		send_error_message(207, req);
-	send_error_message(200, req);
-	return (0);
-}
+// int	Server::process_post(const Request& req)
+// {
+	
+// }
 
 int	Server::send_error_message(int error_code, const Request& req)
 {

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -168,6 +168,9 @@ int	Server::process_request(const Request& req)
 		case DELETE:
 			return (process_delete(req));
 			break;
+		// case POST:
+		// 	return (process_post(req))<
+		// 	break;
 	}
 	return (1);
 }
@@ -212,6 +215,11 @@ int	Server::process_delete(const Request& req)
 		send_error_message(404, req);
 	return (0);
 }
+
+// int	Server::process_post(const Request& req)
+// {
+	
+// }
 
 int	Server::send_error_message(int error_code, const Request& req)
 {

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -218,7 +218,6 @@ int	Server::process_delete(const Request& req)
 
 int	Server::process_post(const Request& req)
 {
-	std::cout << "I AM HERE" << std::endl;
 	long unsigned int	failed = 0;
 	for (const auto& entry : req._post_files)
 	{
@@ -229,11 +228,9 @@ int	Server::process_post(const Request& req)
 		if (!out_file)
 		{
 			failed++;
-	std::cout << "I AM HERE2222" << std::endl;
 			continue;
 		}
 		out_file << content;
-		// out_file.write(content.c_str(), content.size()); 
 		out_file.close();
 	}
 	if (failed == req._post_files.size())

--- a/server/Server.hpp
+++ b/server/Server.hpp
@@ -20,6 +20,7 @@ class Server
 		void				load_mime_types(const std::string& file_path);
 		int					process_get(const Request& req);
 		int					process_delete(const Request& req);
+		int					process_post(const Request& req);
 		std::string			extract_get_request(const std::string& request);
 		std::string			map_to_directory(const std::string& file_path);
 		bool				file_exists(const std::string& file_path);

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -1,0 +1,8 @@
+#ifndef UTILS_H
+# define UTILS_H
+
+# include "../webserv.h"
+
+std::vector<std::string>	tokenize(const std::string& str, const std::string& delim);
+
+#endif

--- a/utils/utils1.cpp
+++ b/utils/utils1.cpp
@@ -1,0 +1,20 @@
+#include "utils.h"
+
+
+std::vector<std::string>	tokenize(const std::string& str, const std::string& delim)
+{
+	std::vector<std::string>	tokens;
+	size_t	start = 0;
+	size_t	end = str.find(delim);
+
+	while (end != std::string::npos)
+	{
+		tokens.push_back(str.substr(start, end - start));
+		start = end + 1;
+		end = str.find(delim, start);
+	}
+
+	tokens.push_back(str.substr(start));
+
+	return (tokens);
+}

--- a/webserv.h
+++ b/webserv.h
@@ -26,6 +26,7 @@
 # include "server/Server.hpp"
 # include "server/Request.hpp"
 # include "exceptions/Exceptions.hpp"
+# include "utils/utils.h"
 
 # ifndef PORT
 #  define PORT 8080


### PR DESCRIPTION
Added POST Request for multipart forms (single still missing)
Changed Reading significantly:
Server reads until the end of the header is encountered and (if applicable) the content_lenght has been read.
It would probably be good to move the entire running operations into its own class at some point, However it makes most sense doing that when implementing running multiple servers