### PR TITLE
Feat/32 keep alive timeout and send timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ SERVER_SRC		:= Server.cpp Request.cpp SocketManager.cpp
 
 EXCEPTIONS_SRC	:= Exception_server.cpp Exception_request.cpp
 
-PARSER_SRC		:= 	Stringing/StringHelp.cpp Stringing/StringArr.cpp Stringing/Pair.cpp \
-					Stringing/Twin.cpp Stringing/StringDataTracker.cpp Parsing/ConfigParse.cpp \
-					Parsing/ConfigData.cpp Parsing/parse_config_file.cpp
+PARSER_SRC		:= 	stringing/StringHelp.cpp stringing/StringArr.cpp stringing/Pair.cpp \
+					stringing/Twin.cpp stringing/StringDataTracker.cpp parsing/ConfigParse.cpp \
+					parsing/ConfigData.cpp parsing/parse_config_file.cpp
 
 SRCS			:= $(SRC) $(UTILS_SRC) $(SERVER_SRC) $(EXCEPTIONS_SRC) $(PARSER_SRC)
 

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,13 @@ SERVER_SRC		:= Server.cpp Request.cpp SocketManager.cpp
 
 EXCEPTIONS_SRC	:= Exception_server.cpp Exception_request.cpp
 
-PARSER_SRC		:= 	stringing/StringHelp.cpp stringing/StringArr.cpp stringing/Pair.cpp \
+PARSER_SRC		:= stringing/StringHelp.cpp stringing/StringArr.cpp stringing/Pair.cpp \
 					stringing/Twin.cpp stringing/StringDataTracker.cpp parsing/ConfigParse.cpp \
 					parsing/ConfigData.cpp parsing/parse_config_file.cpp
 
-SRCS			:= $(SRC) $(UTILS_SRC) $(SERVER_SRC) $(EXCEPTIONS_SRC) $(PARSER_SRC)
+LOG_SRC			:= log/Logger.cpp
+
+SRCS			:= $(SRC) $(UTILS_SRC) $(SERVER_SRC) $(EXCEPTIONS_SRC) $(PARSER_SRC) $(LOG_SRC)
 
 OBJS			:= $(addprefix $(OBJ_DIR)/, $(SRCS:%.cpp=%.o))
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ OBJS			:= $(addprefix $(OBJ_DIR)/, $(SRCS:%.cpp=%.o))
 all: submodule $(NAME)
 
 submodule:
-	git submodule update --init --recursive
+	@git submodule update --init --recursive
 
 $(NAME): $(OBJS)
 	$(CPP) $(CPPFLAGS) $(OBJS) -o $(NAME)

--- a/config_files/standart.conf
+++ b/config_files/standart.conf
@@ -7,8 +7,8 @@ http
 		index				index.html;
 		listen				8080;
 		root				www_image_webpage;
-		keepalive_timeout	0;
-		send_timeout		0;
+		keepalive_timeout	5;
+		send_timeout		5;
 		max_body_size		3000000;
 		directory_listing	true;
 		location /42heilbronn {
@@ -22,8 +22,8 @@ http
 		index				index.html;
 		listen				8081;
 		root				www;
-		keepalive_timeout	0;
-		send_timeout		0;
+		keepalive_timeout	5;
+		send_timeout		5;
 		max_body_size		3000000;
 		directory_listing	true;
 		location /42heilbronn {

--- a/exceptions/Exceptions.hpp
+++ b/exceptions/Exceptions.hpp
@@ -90,4 +90,11 @@ class SendFailedException : public BaseException
 		explicit SendFailedException(const std::string& server_name, const int& fd);
 };
 
+class PollFailedException : public BaseException
+{
+	public:
+		explicit PollFailedException(void)
+		: BaseException("Poll failed") {}
+};
+
 #endif /*EXCEPTIONS_HPP*/

--- a/log/Logger.cpp
+++ b/log/Logger.cpp
@@ -6,8 +6,13 @@
 
 Logger::Logger()
 {
+	const std::filesystem::path&	folder1 = "log/server";
+	const std::filesystem::path&	folder2 = "log/error";
+	if (!std::filesystem::exists(folder1))
+		std::filesystem::create_directories(folder1);
+	if (!std::filesystem::exists(folder2))
+		std::filesystem::create_directories(folder2);
 	std::string	time = get_time();
-	const std::filesystem::path&	folder1 = "/log/server";
 	if (std::filesystem::exists(folder1) && std::filesystem::is_directory(folder1))
 	{
 		for (const auto& entry : std::filesystem::directory_iterator(folder1))
@@ -18,9 +23,18 @@ Logger::Logger()
 			}
 		}
 	}
-	delete_oldest_file("/log/error", 5);
-	_server_log.open("/log/server/" + time + "server.log");
-	_error_log.open("/log/error/" + time + "server.error.log");
+	delete_oldest_file("log/error", 5);
+	_server_log.open(("log/server/" + time + "server.log"));
+	// _server_log.open("log/server/test");
+	if (!_server_log.is_open())
+	{
+		throw std::ios_base::failure("Failed to open server log file");
+	}
+	_error_log.open("log/error/" + time + "server.error.log");
+	if (!_error_log.is_open())
+	{
+		throw std::ios_base::failure("Failed to open error log file");
+	}
 }
 
 Logger::~Logger()
@@ -45,11 +59,14 @@ void	Logger::delete_oldest_file(const std::filesystem::path& folder, size_t max_
 		{
 			if (std::filesystem::is_regular_file(entry.status()) && entry.path().extension() == ".log")
 			{
-				files.emplace_back(entry.path(), std::filesystem::last_write_time(entry));
+				auto	ftime = std::filesystem::last_write_time(entry);
+				auto	cftime = std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+					ftime - std::filesystem::file_time_type::clock::now() + std::chrono::system_clock::now());
+				files.emplace_back(entry.path(), cftime);
 			}
 		}
 	}
-	if (files.size() > max_files)
+	if (files.size() >= max_files)
 	{
 		std::sort(files.begin(), files.end(), [](const auto& a, const auto& b) {
 			return (a.second < b.second);
@@ -64,25 +81,33 @@ void	Logger::delete_oldest_file(const std::filesystem::path& folder, size_t max_
  * @brief Adds a log to the logfile
  * @param server_name the name of the server, empty if the error is general
  * @param message the message, in the standart format, has to be in the Common Log Format for the server log
- * @param level 0 for DEBUG, 1 for INFO, 2 for WARNING, 3 for ERROR, ERROR only for FATAL error meaning server failure
+ * @param level 0 for DEBUG, 1 for CLF, 2 for INFO to error log, 3 for WARNING, 4 for ERROR, ERROR only for FATAL error meaning server failure
  */
 void	Logger::log(const std::string& server_name, const std::string& message, int level)
 {
 	std::string	time = get_time();
+	std::string	msg = message;
+	if (!server_name.empty())
+	{
+		msg = server_name + ":\t" + message;
+	}
 	switch (level)
 	{
 		case 1:
-			_server_log << message << std::endl;
+			_server_log << msg << std::endl;
 			break;
 		case 0:
-			_error_log << time << " [DEBUG]\t" << message << std::endl;
+			_error_log << time << " [DEBUG]\t" << msg << std::endl;
 			break;
 		case 2:
-			_error_log << time << " [WARNING\t]" << message << std::endl;
+			_error_log << time << " [INFO]\t" << msg << std::endl;
 			break;
 		case 3:
-			_error_log << time << " [ERROR\t]" << message << std::endl;
-			_server_log << time << " [ERROR\t]" << message << std::endl;
+			_error_log << time << " [WARNING]\t" << msg << std::endl;
+			break;
+		case 4:
+			_error_log << time << " [ERROR]\t" << msg << std::endl;
+			_server_log << time << " [ERROR]\t" << msg << std::endl;
 			break;
 		default:
 			break;
@@ -95,7 +120,7 @@ std::string	Logger::get_time()
 	std::time_t	now = std::time(NULL);
 	std::tm local_tm = *std::localtime(&now);
 	char	buffer[100];
-	std::string	format = "%d/%b/%Y:%H:%M:%S";
+	std::string	format = "[%d-%m-%Y:%H:%M:%S]";
 	if (std::strftime(buffer, sizeof(buffer), format.c_str(), &local_tm))
 	{
 		time = std::string(buffer);

--- a/log/Logger.cpp
+++ b/log/Logger.cpp
@@ -1,0 +1,108 @@
+#include "Logger.hpp"
+
+/* -------------------------------------------------------------------------- */
+/*                           Orthodox Canonical Form                          */
+/* -------------------------------------------------------------------------- */
+
+Logger::Logger()
+{
+	std::string	time = get_time();
+	const std::filesystem::path&	folder1 = "/log/server";
+	if (std::filesystem::exists(folder1) && std::filesystem::is_directory(folder1))
+	{
+		for (const auto& entry : std::filesystem::directory_iterator(folder1))
+		{
+			if (std::filesystem::is_regular_file(entry.status()) && entry.path().extension() == ".log")
+			{
+				std::filesystem::remove(entry.path());
+			}
+		}
+	}
+	delete_oldest_file("/log/error", 5);
+	_server_log.open("/log/server/" + time + "server.log");
+	_error_log.open("/log/error/" + time + "server.error.log");
+}
+
+Logger::~Logger()
+{
+	if (_server_log.is_open())
+		_server_log.close();
+	if (_error_log.is_open())
+		_error_log.close();
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Functions                                 */
+/* -------------------------------------------------------------------------- */
+
+void	Logger::delete_oldest_file(const std::filesystem::path& folder, size_t max_files)
+{
+	std::vector<std::pair<std::filesystem::path, std::chrono::system_clock::time_point>>	files;
+
+	if (std::filesystem::exists(folder) && std::filesystem::is_directory(folder))
+	{
+		for (const auto& entry : std::filesystem::directory_iterator(folder))
+		{
+			if (std::filesystem::is_regular_file(entry.status()) && entry.path().extension() == ".log")
+			{
+				files.emplace_back(entry.path(), std::filesystem::last_write_time(entry));
+			}
+		}
+	}
+	if (files.size() > max_files)
+	{
+		std::sort(files.begin(), files.end(), [](const auto& a, const auto& b) {
+			return (a.second < b.second);
+		});
+		std::filesystem::remove(files.front().first);
+	}
+}
+
+// DEBUG, INFO, WARNING, ERROR
+
+/**
+ * @brief Adds a log to the logfile
+ * @param server_name the name of the server, empty if the error is general
+ * @param message the message, in the standart format, has to be in the Common Log Format for the server log
+ * @param level 0 for DEBUG, 1 for INFO, 2 for WARNING, 3 for ERROR, ERROR only for FATAL error meaning server failure
+ */
+void	Logger::log(const std::string& server_name, const std::string& message, int level)
+{
+	std::string	time = get_time();
+	switch (level)
+	{
+		case 1:
+			_server_log << message << std::endl;
+			break;
+		case 0:
+			_error_log << time << " [DEBUG]\t" << message << std::endl;
+			break;
+		case 2:
+			_error_log << time << " [WARNING\t]" << message << std::endl;
+			break;
+		case 3:
+			_error_log << time << " [ERROR\t]" << message << std::endl;
+			_server_log << time << " [ERROR\t]" << message << std::endl;
+			break;
+		default:
+			break;
+	}
+}
+
+std::string	Logger::get_time()
+{
+	std::string	time;
+	std::time_t	now = std::time(NULL);
+	std::tm local_tm = *std::localtime(&now);
+	char	buffer[100];
+	std::string	format = "%d/%b/%Y:%H:%M:%S";
+	if (std::strftime(buffer, sizeof(buffer), format.c_str(), &local_tm))
+	{
+		time = std::string(buffer);
+	}
+	else
+	{
+		time = "Error-Formating-Time";
+	}
+	return (time);
+}

--- a/log/Logger.hpp
+++ b/log/Logger.hpp
@@ -1,0 +1,29 @@
+#ifndef LOGGER_HPP
+# define LOGGER_HPP
+
+# include "../webserv.h"
+
+class Logger
+{
+	private:
+		Logger();
+		~Logger();
+		std::ofstream _server_log;
+		std::ofstream _error_log;
+		
+		void		delete_oldest_file(const std::filesystem::path& folder, size_t max_files);
+		std::string	get_time();
+	public:
+		static Logger&	getInstance()
+		{
+			static Logger	instance;
+			return (instance);
+		}
+
+		Logger(const Logger& copy) = delete;
+		void	operator=(const Logger& copy) = delete;
+
+		void	log(const std::string& server_name, const std::string& message, int level);
+};
+
+#endif /*LOGGER_HPP*/

--- a/main.cpp
+++ b/main.cpp
@@ -20,28 +20,26 @@ int main(int argc, char **argv)
 		return 0;
 	}
 
-	//receiving values from the `example1.config`:
-	// fill_server_data(servers); //what the parser from the config will fill out
-	// print_server_data(servers); // for verification
-	// (void)argv;
-	
+	std::vector<ServerData> server_vec;
+	try
+	{
+		server_vec = read_config_file(argv[1]);
+	}
+	catch(const std::exception& e)
+	{
+		std::cerr << e.what() << '\n';
+		return (0);
+	}
 
 	try
 	{
 		SocketManager	socket_manager;
-		try
+		
+		for (size_t s = 0; s < server_vec.size(); s++)
 		{
-			std::vector<ServerData> server_vec = read_config_file(argv[1]);
-			for (size_t s = 0; s < server_vec.size(); s++)
-			{
-				ServerData const & server = server_vec[s];
-				socket_manager.add_server(server.port_to_listen, std::make_unique<Server>(server.server_name, server.port_to_listen, "0.0.0.0", server.index_file,
-				"usrimg", server.root, server.directory_listing, server.keepalive_timeout, server.send_timeout, server.max_request_size));
-			}
-		}
-		catch(const std::exception& e)
-		{
-			std::cerr << "Exception: " << e.what() << std::endl;
+			ServerData const & server = server_vec[s];
+			socket_manager.add_server(server.port_to_listen, std::make_unique<Server>(server.server_name, server.port_to_listen, "0.0.0.0", server.index_file,
+			"usrimg", server.root, server.directory_listing, server.keepalive_timeout, server.send_timeout, server.max_request_size));
 		}
 		// socket_manager.add_server(8080, std::make_unique<Server>("Instalight", 8080, "0.0.0.0", "index.html", "usrimg", "www_image_webpage", true, 0, 0, 3000000));
 		// socket_manager.add_server(8081, std::make_unique<Server>("A little webserver", 8081, "0.0.0.0", "index.html", "usrimg", "www", true, 0, 0, 3000000));
@@ -49,9 +47,7 @@ int main(int argc, char **argv)
 	}
 	catch (const std::exception& e)
 	{
-		std::cerr << "Exception: " << e.what() << std::endl;
+			Logger::getInstance().log("", e.what(), 4);
 	}
 	return (0);
 }
-
-

--- a/parser/parsing/ConfigParse.cpp
+++ b/parser/parsing/ConfigParse.cpp
@@ -24,10 +24,10 @@ ConfigParse::ConfigParse(
 	this -> new_func = new_func;
 	this -> set_func = set_func;
 
-	if (new_func == NULL && set_func == NULL)
-	{
-		std::cout << "NOTE: Configuration Parsing Element '" << name << "' was given neither a new() nor a set() function.\n";
-	}
+	// if (new_func == NULL && set_func == NULL)
+	// {
+	// 	std::cout << "NOTE: Configuration Parsing Element '" << name << "' was given neither a new() nor a set() function.\n";
+	// }
 }
 ConfigParse::ConfigParse(ConfigParse const & othr) :
 	name(othr.name),

--- a/parser/parsing/parse_config_file.cpp
+++ b/parser/parsing/parse_config_file.cpp
@@ -85,10 +85,8 @@ std::vector<ServerData>	read_config_file(std::string file)
 
 	ConfigData::MainData data;
 	parseConfig(conf, &data);
-	std::cout << "INFO: config file reading done\n";
-	//std::cout << "\n";
-	//data.print();
-	//std::cout << "\n";
+	// std::cout << "INFO: config file reading done\n";
+	Logger::getInstance().log("", "Config file read", 2);
 
 	if (data.http.size() == 0)
 	{
@@ -136,7 +134,8 @@ std::vector<ServerData>	read_config_file(std::string file)
 		}
 	}
 
-	std::cout << "INFO: config data interpreting done\n";
+	// std::cout << "INFO: config data interpreting done\n";
+	Logger::getInstance().log("", "Config file interpreted", 2);
 
 	return (server_vec);
 }

--- a/parser/parsing/parse_config_file.hpp
+++ b/parser/parsing/parse_config_file.hpp
@@ -10,6 +10,7 @@
 #include "../stringing/StringDataTracker.hpp"
 #include "ConfigParse.hpp"
 #include "ConfigData.hpp"
+#include "../../log/Logger.hpp"
 
 struct LocationData
 {

--- a/server/Request.cpp
+++ b/server/Request.cpp
@@ -6,7 +6,6 @@
 
 Request::Request(size_t fd)
 {
-	std::cout << "Request Constructed" << std::endl;
 	_fd = fd;
 	_method = -1;
 	_content_len = 0;
@@ -18,7 +17,6 @@ Request::Request(size_t fd)
 
 Request::Request()
 {
-	std::cout << "Request Constructed" << std::endl;
 	_method = -1;
 	_content_len = 0;
 	_port = -1;
@@ -118,7 +116,7 @@ int		Request::read_chunk(std::vector<char> buffer, int bytes_read)
 	{
 		if (_body_bytes_read >= _content_len)
 		{
-			std::cout << "HEADER:\n" << _header << std::endl;
+			// std::cout << "HEADER:\n" << _header << std::endl;
 			if (fill_in_request() == 1)
 				return (-1);
 			return (0);
@@ -126,7 +124,7 @@ int		Request::read_chunk(std::vector<char> buffer, int bytes_read)
 	}
 	if (_header_parsed && _content_len == 0)
 	{
-		std::cout << "HEADER:\n" << _header << std::endl;
+		// std::cout << "HEADER:\n" << _header << std::endl;
 		if (fill_in_request() == 1)
 			return (-1);
 		_finished_reading = true;
@@ -140,7 +138,7 @@ int	Request::fill_in_request(void)
 	std::time_t	now = std::time(NULL);
 	std::tm local_tm = *std::localtime(&now);
 	char	buffer[100];
-	std::string	format = "%d/%b/%Y:%H:%M:%S %z";
+	std::string	format = "[%d/%b/%Y:%H:%M:%S %z]";
 	if (std::strftime(buffer, sizeof(buffer), format.c_str(), &local_tm))
 	{
 		_request_received_time = std::string(buffer);
@@ -152,12 +150,13 @@ int	Request::fill_in_request(void)
 	std::string::size_type pos = _header.find('\n');
 	if (pos != std::string::npos) 
 	{
-		_request_line = _header.substr(0, pos);
+		_request_line = _header.substr(0, pos -1);
 	}
 	else
 	{
 		_request_line = "Error-Finding-Request_Line";
 	}
+	_CLF_line = _client_ip + "\t" + std::to_string(_fd) + "\t- " + _request_received_time + "\t\"" + _request_line + "\"";
 
 	std::string::size_type	method;
 	if (_header.compare(0, 3, "GET") == 0)
@@ -355,4 +354,10 @@ void	Request::reset()
 	_request_received_time.clear();
 	_request_line.clear();
 	_post_files.clear();
+	_CLF_line.clear();
+}
+
+std::string	Request::get_CLF_line(void) const
+{
+	return (_CLF_line);
 }

--- a/server/Request.cpp
+++ b/server/Request.cpp
@@ -149,9 +149,15 @@ int	Request::fill_in_request(void)
 	{
 		_request_received_time = "Error-Formating-Time";
 	}
-
-	std::cout << "FD: " << _fd << std::endl;
-	std::cout << "IP-Address: " << _client_ip << std::endl;
+	std::string::size_type pos = _header.find('\n');
+	if (pos != std::string::npos) 
+	{
+		_request_line = _header.substr(0, pos);
+	}
+	else
+	{
+		_request_line = "Error-Finding-Request_Line";
+	}
 
 	std::string::size_type	method;
 	if (_header.compare(0, 3, "GET") == 0)

--- a/server/Request.cpp
+++ b/server/Request.cpp
@@ -61,16 +61,10 @@ int		Request::read_chunk(std::vector<char> buffer, int bytes_read)
 		return (0);
 	if (bytes_read < 0)
 	{
-		// std::cerr << "Error reading from fd " << fds[i].fd << std::endl;
-		// close(fds[i].fd);
-		// fds[i].fd = -1;
 		return (-1);
 		}
 	if (bytes_read == 0)
 	{
-		// std::cout << "Client on fd " << fds[i].fd << " disconnected" << std::endl;
-		// close(fds[i].fd);
-		// fds[i].fd = -1;
 		return (-2);
 	}
 	_accumulated_request.insert(_accumulated_request.end(), buffer.begin(), buffer.begin() + bytes_read);
@@ -276,4 +270,19 @@ bool	Request::get_finished_reading(void) const
 std::string	Request::get_host(void) const
 {
 	return (_host);
+}
+
+std::string	Request::get_client_ip(void) const
+{
+	return (_client_ip);
+}
+
+std::string	Request::get_request_received_time(void) const
+{
+	return (_request_received_time);
+}
+
+std::string	Request::get_request_line(void) const
+{
+	return (_request_line);
 }

--- a/server/Request.cpp
+++ b/server/Request.cpp
@@ -37,6 +37,16 @@ Request::Request(const Request& copy)
 	// std::cout << "Request Copy Constructor called" << std::endl;
 	if (this != &copy)
 	{
+		this->_fd = copy._fd;
+		this->_client_ip = copy._client_ip;
+		// this->_method = copy._method;
+		// this->_content_len = copy._content_len;
+		// this->_port = copy._port;
+		// this->_body_bytes_read = copy._body_bytes_read;
+		// this->_header_parsed = copy._header_parsed;
+		// this->_finished_reading = copy._finished_reading;
+		// this->_file_path = copy._file_path;
+		// this->_host = copy._host;
 	}
 }
 
@@ -45,7 +55,9 @@ Request&	Request::operator=(const Request &copy)
 	// std::cout << "Request Copy Assignment called" << std::endl;
 	if (this != &copy)
 	{
-	}
+		this->_fd = copy._fd;
+		this->_client_ip = copy._client_ip;
+}
 	return (*this);
 }
 
@@ -125,6 +137,22 @@ int		Request::read_chunk(std::vector<char> buffer, int bytes_read)
 
 int	Request::fill_in_request(void)
 {
+	std::time_t	now = std::time(NULL);
+	std::tm local_tm = *std::localtime(&now);
+	char	buffer[100];
+	std::string	format = "%d/%b/%Y:%H:%M:%S %z";
+	if (std::strftime(buffer, sizeof(buffer), format.c_str(), &local_tm))
+	{
+		_request_received_time = std::string(buffer);
+	}
+	else
+	{
+		_request_received_time = "Error-Formating-Time";
+	}
+
+	std::cout << "FD: " << _fd << std::endl;
+	std::cout << "IP-Address: " << _client_ip << std::endl;
+
 	std::string::size_type	method;
 	if (_header.compare(0, 3, "GET") == 0)
 	{
@@ -285,4 +313,40 @@ std::string	Request::get_request_received_time(void) const
 std::string	Request::get_request_line(void) const
 {
 	return (_request_line);
+}
+
+void	Request::set_fd(size_t fd)
+{
+	_fd = fd;
+}
+
+void	Request::set_client_ip(uint32_t ip_binary)
+{
+	std::string	ip_str;
+
+	for (int i = 0; i < 4; i++)
+	{
+		if (i != 0)
+			ip_str += ".";
+		ip_str += std::to_string((ip_binary >> (8 * i)) & 0xFF);
+	}
+	_client_ip = ip_str;
+}
+
+void	Request::reset()
+{
+	_method = -1;
+	_file_path.clear();
+	_content_len = 0;
+	_host.clear();
+	_port = -1;
+	_content_type.clear();
+	_header.clear();
+	_accumulated_request.clear();
+	_body_bytes_read = 0;
+	_header_parsed = false;
+	_finished_reading = false;
+	_request_received_time.clear();
+	_request_line.clear();
+	_post_files.clear();
 }

--- a/server/Request.hpp
+++ b/server/Request.hpp
@@ -64,6 +64,11 @@ class Request
 		std::string	get_client_ip(void) const;
 		std::string	get_request_received_time(void) const;
 		std::string	get_request_line(void) const;
+
+		void		set_fd(size_t fd);
+		void		set_client_ip(uint32_t ip_binary);
+
+		void		reset();
 };
 
 #endif /*REQUEST_HPP*/

--- a/server/Request.hpp
+++ b/server/Request.hpp
@@ -38,6 +38,7 @@ class Request
 		std::string			_client_ip;
 		std::string			_request_received_time;
 		std::string			_request_line;
+		std::string			_CLF_line;
 
 		int			fill_in_request(void);
 
@@ -64,6 +65,7 @@ class Request
 		std::string	get_client_ip(void) const;
 		std::string	get_request_received_time(void) const;
 		std::string	get_request_line(void) const;
+		std::string	get_CLF_line(void) const;
 
 		void		set_fd(size_t fd);
 		void		set_client_ip(uint32_t ip_binary);

--- a/server/Request.hpp
+++ b/server/Request.hpp
@@ -35,6 +35,10 @@ class Request
 		bool				_header_parsed;
 		bool				_finished_reading;
 
+		std::string			_client_ip;
+		std::string			_request_received_time;
+		std::string			_request_line;
+
 		int			fill_in_request(void);
 
 		int			process_post(void);
@@ -57,6 +61,9 @@ class Request
 		bool		get_finished_reading(void) const;
 		int			get_port(void) const;
 		std::string	get_host(void) const;
+		std::string	get_client_ip(void) const;
+		std::string	get_request_received_time(void) const;
+		std::string	get_request_line(void) const;
 };
 
 #endif /*REQUEST_HPP*/

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -82,9 +82,6 @@ Server::Server(const std::string server_name, int port, const std::string ip_add
 		close(_fd_server);
 		throw ListenFailedException(_name);
 	}
-
-	int temp = _send_timeout + _keepalive_timeout + _directory_listing_enabled + _max_body_size;
-	std::cout << temp << std::endl;
 	std::cout << "Server is now listening on port " << port << std::endl;
 }
 

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -24,7 +24,7 @@ Server::Server(const std::string server_name, int port, const std::string ip_add
 	_directory_listing_enabled(directory_listing_enabled), _keepalive_timeout(keepalive_timeout),
 	_send_timeout(send_timeout), _max_body_size(max_body_size)
 {
-	std::cout << "Server Default Constructor called" << std::endl;
+	Logger::getInstance().log(server_name, "Constructor called", 2);
 	load_mime_types("mime_type.csv");
 	_fd_server = socket(AF_INET, SOCK_STREAM, 0);
 	if (_fd_server == -1)
@@ -82,12 +82,13 @@ Server::Server(const std::string server_name, int port, const std::string ip_add
 		close(_fd_server);
 		throw ListenFailedException(_name);
 	}
-	std::cout << "Server is now listening on port " << port << std::endl;
+	Logger::getInstance().log(server_name, "Server is now listening on " + std::to_string(port), 2);
+
 }
 
 Server::~Server()
 {
-	std::cout << "Server Default Destructor called" << std::endl;
+	Logger::getInstance().log(_name, "Destructor called", 2);
 	close(_fd_server);
 }
 
@@ -128,6 +129,7 @@ std::string	Server::get_mime_type(const std::string& file_path)
 	}
 	catch (const std::out_of_range& e)
 	{
+		Logger::getInstance().log(_name, file_path + " has unknown MIME Type", 3);
 		return ("unknown/unknown");
 	}
 }
@@ -161,6 +163,7 @@ void	Server::load_mime_types(const std::string& file_path)
 
 std::string	Server::process_request(const Request& req)
 {
+	_CLF_line = req.get_CLF_line();
 	int	method = req.get_method();
 
 	switch (method)
@@ -199,11 +202,11 @@ std::string	Server::process_get(const Request& req)
 			response_body += "    <li><a href=\"" + _data_dir + "/" + entry.path().filename().string() + "\">" + entry.path().filename().string() + "</a></li>\n";
 		}
 		response_body += "</ul>\n<hr>\n</body>\n</html>\n";
-		response += "Content-Length: " + std::to_string(response_body.size()) + "\r\n";
+		std::string	con_len_str = std::to_string(response_body.size());
+		response += "Content-Length: " + con_len_str + "\r\n";
 		response += "\r\n";
 		response += response_body;
-		// if (send(req.get_fd(), response.c_str(), response.size(), 0) == -1)
-		// 		throw SendFailedException(_name, req.get_fd());
+		_CLF_line += " " + std::to_string(200) + " " + con_len_str;
 		return (response);
 	}
 	else if (_directory_listing_enabled == false && std::filesystem::is_directory(file_path))
@@ -215,11 +218,11 @@ std::string	Server::process_get(const Request& req)
 		std::string	file_content = read_file(file_path);
 		std::string	mime_type = get_mime_type(file_path);
 		response += "Content-Type: " + mime_type + "\r\n";
-		response += "Content-Length: " + std::to_string(file_content.size()) + "\r\n";
+		std::string	con_len_str = std::to_string(file_content.size());
+		response += "Content-Length: " + con_len_str + "\r\n";
 		response += "\r\n";
 		response += file_content;
-		// if (send(req.get_fd(), response.c_str(), response.size(), 0) == -1)
-		// 		throw SendFailedException(_name, req.get_fd());
+		_CLF_line += " " + std::to_string(200) + " " + con_len_str;
 		return (response);
 	}
 	else
@@ -284,25 +287,24 @@ std::string	Server::send_error_message(int error_code)
 		std::string	mime_type = get_mime_type(file_path);
 		std::string	response = "HTTP/1.1 " + std::to_string(error_code) + " Error\r\n";
 		response += "Content-Type: " + mime_type + "\r\n";
-		response += "Content-Length: " + std::to_string(file_content.size()) + "\r\n";
+		std::string	con_len_str = std::to_string(file_content.size());
+		response += "Content-Length: " + con_len_str + "\r\n";
 		response += "\r\n";
 		response += file_content;
-		// if (send(req.get_fd(), response.c_str(), response.size(), 0) == -1)
-		// 		throw SendFailedException(_name, req.get_fd());
+		_CLF_line += " " + std::to_string(error_code) + " " + con_len_str;
 		return (response);
 	}
 	else
 	{
 		std::string response = "HTTP/1.1 404 Not Found\r\n";
 		response += "Content-Type: text/html\r\n";
-		response += "Content-Length: " + std::to_string(strlen("404 File Not Found")) + "\r\n";
+		std::string	con_len_str = std::to_string(strlen("404 File Not Found"));
+		response += "Content-Length: " + con_len_str + "\r\n";
 		response += "\r\n"; // End of headers
 		response += "404 File Not Found"; // Body
-		// if (send(req.get_fd(), response.c_str(), response.size(), 0) == -1)
-		// 	throw SendFailedException(_name, req.get_fd());
+		_CLF_line += " " + std::to_string(error_code) + " " + con_len_str;
 		return (response);
 	}
-	// return (0);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -327,4 +329,9 @@ const std::string	Server::getName(void) const
 size_t	Server::getMaxBodySize(void) const
 {
 	return (_max_body_size);
+}
+
+void	Server::log_CLF_line(void)
+{
+	Logger::getInstance().log(_name, _CLF_line, 1);
 }

--- a/server/Server.hpp
+++ b/server/Server.hpp
@@ -18,6 +18,7 @@ class Server
 		size_t				_keepalive_timeout;
 		size_t				_send_timeout;
 		size_t				_max_body_size;
+		std::string			_CLF_line;
 		std::unordered_map<std::string, std::string> _mime_types;
 
 		void				load_mime_types(const std::string& file_path);
@@ -40,6 +41,7 @@ class Server
 		size_t				getMaxBodySize(void) const;
 		std::string			process_request(const Request& req);
 		std::string			send_error_message(int error_code);
+		void				log_CLF_line(void);
 };
 
 #endif /*SERVER_HPP*/

--- a/server/SocketManager.cpp
+++ b/server/SocketManager.cpp
@@ -105,15 +105,15 @@ void	SocketManager::handle_read(int client_fd)
 			{
 				switch (status)
 				{
-				case 0:
-					response = _server_map[port]->process_request(_request_map[client_fd]);
-					break;
-				case -10:
-					response = _server_map[port]->send_error_message(413);
-					break;
-				default:
-					response = _server_map[port]->send_error_message(400);
-					break;
+					case 0:
+						response = _server_map[port]->process_request(_request_map[client_fd]);
+						break;
+					case -10:
+						response = _server_map[port]->send_error_message(413);
+						break;
+					default:
+						response = _server_map[port]->send_error_message(400);
+						break;
 				}
 				_response_map[client_fd] = response;
 				_request_map[client_fd].reset();

--- a/server/SocketManager.cpp
+++ b/server/SocketManager.cpp
@@ -102,6 +102,8 @@ void	SocketManager::handle_read(int client_fd)
 			std::string	response;
 			if (_server_map.find(port) != _server_map.end())
 			{
+				//! If we want to make the server perfect, we add another map taking the client fd and a bool.
+				//! should the response fail, leading us to return a 400 or 413 we then set this to true, letting us know to disconnect the client after sending
 				switch (status)
 				{
 					case 0:
@@ -131,7 +133,6 @@ void	SocketManager::handle_read(int client_fd)
 void	SocketManager::handle_write(int client_fd)
 {
 	auto&	response = _response_map[client_fd];
-	// std::cout << "Response:\n" << response << std::endl;
 	ssize_t	bytes_sent = send(client_fd, response.c_str(), response.size(), 0);
 
 	if (bytes_sent == -1)
@@ -149,7 +150,6 @@ void	SocketManager::handle_write(int client_fd)
 			// remove_client(client_fd);
 		}
 	}
-	// std::cout << "I FINISHED HELLO" << std::endl;
 }
 
 

--- a/webserv.h
+++ b/webserv.h
@@ -26,6 +26,7 @@
 # include <cstdio>
 # include <filesystem>
 # include <fcntl.h>
+# include <chrono>
 
 # include "exceptions/Exceptions.hpp"
 // # include "SocketsController/SocketsControl.hpp"

--- a/webserv.h
+++ b/webserv.h
@@ -11,6 +11,7 @@
 # include <sys/types.h>
 # include <sys/socket.h>
 # include <netinet/in.h>
+# include <netinet/tcp.h>
 # include <unistd.h>
 # include <fcntl.h>
 # include <climits>

--- a/webserv.h
+++ b/webserv.h
@@ -31,7 +31,8 @@
 // # include "SocketsController/SocketsControl.hpp"
 // # include "SocketsController/structs.hpp"
 # include "utils/utils.h"
-#include "parser/parsing/parse_config_file.hpp"
+# include "parser/parsing/parse_config_file.hpp"
+# include "log/Logger.hpp"
 
 // some output formatting macros:
 # define BOLD(text) "\033[1m" << text << "\033[0m"


### PR DESCRIPTION
Closes #32

Added a keep alive and a send timeout
Both are currenctly set to 5s but we should check if that is a good time

Changed some layout inside the SocketManager, making it more readable.

Added a Logger class.
This class is a singleton class (only one object can be instantiated).
The class creates two types of files, a server log and an error log.
There is only one server_log, the oldone being deleted once the server is restarted.
The 5 oldest error logs stay saved.

Logger::getInstance().log() to use it. Log takes three arguments, the server name which can be "" to be ingored, a message and lastly the error level.
There are 5 error levels:
0: A Debug message which is written to the error log

1: A Message for the server log. This message has to be written in the Common Log format (https://en.wikipedia.org/wiki/Common_Log_Format) For the Common Log Format a variable (CLF_line) is established inside the Request class. If a request object is parsed to the server, the server will complete the line. The line is only completed after a response has been returned. To log the line simply call the Servers function void	log_CLF_line(void).

2: A Info Message written to the error log. Something like "Server is listening on ..."

3: A Warning written to the error log. Something like "Client send wrong request" or "Send failed"

4. An Error message. This message should only be called in case an exception is thrown. Error means fatal, the program is exiting. It is written to both log files.



While doing this I found another issue:
If we cancel reading because of a bad request or most likely a request with larger the max_body_size, it is possible for further data to be stored inside the socket, making the next request also fail.
One option would be to read till we find the next header, something i am loath to do, considering it defeats the purpose of the max body size
An Alternative would be creating a vector or another datatype, storing the fds of clients where a 400 or 413 has been returned. After sending has finished we would then check if the clients fd is inside that vector, in which case we will close the connection.

We could also just leave it like that and consider it normal behaviour (Other teams are reading the entire request no mather what)