### PR TITLE
Feat/mime types and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SRC				:= main.cpp
 
 UTILS_SRC		:= utils1.cpp
 
-SERVER_SRC		:= Server.cpp Request.cpp SocketManager.cpp
+SERVER_SRC		:= Server.cpp Request.cpp SocketManager.cpp MimeTypes.cpp
 
 EXCEPTIONS_SRC	:= Exception_server.cpp Exception_request.cpp
 

--- a/main.cpp
+++ b/main.cpp
@@ -34,7 +34,8 @@ int main(int argc, char **argv)
 	try
 	{
 		SocketManager	socket_manager;
-		
+		MimeTypes::getInstance();
+
 		for (size_t s = 0; s < server_vec.size(); s++)
 		{
 			ServerData const & server = server_vec[s];

--- a/server/MimeTypes.cpp
+++ b/server/MimeTypes.cpp
@@ -1,0 +1,45 @@
+#include "MimeTypes.hpp"
+
+/* -------------------------------------------------------------------------- */
+/*                           Orthodox Canonical Form                          */
+/* -------------------------------------------------------------------------- */
+
+MimeTypes::MimeTypes()
+{
+	std::ifstream file("mime_type.csv");
+	if (!file.is_open())
+		throw OpenFailedException("MimeTypes", "mime_type.csv");
+	std::string	line;
+	while(std::getline(file, line))
+	{
+		std::istringstream	ss(line);
+		std::string			extension;
+		std::string			mime_type;
+
+		if (std::getline(ss, extension, '\t') && std::getline(ss, mime_type))
+			_mime_types[extension] = mime_type;
+	}
+	file.close();
+}
+
+MimeTypes::~MimeTypes()
+{
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Functions                                 */
+/* -------------------------------------------------------------------------- */
+
+std::string	MimeTypes::get_mime_type(const std::string& file_path)
+{
+	std::string	file_extension = file_path.substr(file_path.find_last_of('.'));
+	try
+	{
+		return (_mime_types.at(file_extension));
+	}
+	catch (const std::out_of_range& e)
+	{
+		Logger::getInstance().log("", file_path + " has unknown MIME Type", 3);
+		return ("unknown/unknown");
+	}
+}

--- a/server/MimeTypes.cpp
+++ b/server/MimeTypes.cpp
@@ -32,7 +32,13 @@ MimeTypes::~MimeTypes()
 
 std::string	MimeTypes::get_mime_type(const std::string& file_path)
 {
-	std::string	file_extension = file_path.substr(file_path.find_last_of('.'));
+	size_t		ext_pos = file_path.find_last_of('.');
+	if (ext_pos == std::string::npos)
+	{
+		Logger::getInstance().log("", file_path + " has unknown MIME Type", 3);
+		return ("unknown/unknown");
+	}
+	std::string	file_extension = file_path.substr(ext_pos);
 	try
 	{
 		return (_mime_types.at(file_extension));

--- a/server/MimeTypes.cpp
+++ b/server/MimeTypes.cpp
@@ -43,3 +43,14 @@ std::string	MimeTypes::get_mime_type(const std::string& file_path)
 		return ("unknown/unknown");
 	}
 }
+
+std::string MimeTypes::get_file_extension(const std::string& mime_type)
+{
+	for (const auto& pair : _mime_types)
+	{
+		if (pair.second == mime_type)
+			return (pair.first);
+	}
+	Logger::getInstance().log("", mime_type + " has unknown file extension", 3);
+	return (".unknown");
+}

--- a/server/MimeTypes.hpp
+++ b/server/MimeTypes.hpp
@@ -21,6 +21,7 @@ class MimeTypes
 		void operator=(const MimeTypes& copy) = delete;
 
 		std::string			get_mime_type(const std::string& file_path);
+		std::string			get_file_extension(const std::string& mime_type);
 };
 
 #endif /*MIMETYPES_HPP*/

--- a/server/MimeTypes.hpp
+++ b/server/MimeTypes.hpp
@@ -1,0 +1,26 @@
+#ifndef MIMETYPES_HPP
+# define MIMETYPES_HPP
+
+# include "../webserv.h"
+
+class MimeTypes
+{
+	private:
+		/*args*/
+		MimeTypes();
+		~MimeTypes();
+		std::unordered_map<std::string, std::string> _mime_types;
+	public:
+		static MimeTypes&	getInstance()
+		{
+			static MimeTypes	instance;
+			return (instance);
+		}
+
+		MimeTypes(const MimeTypes& copy) = delete;
+		void operator=(const MimeTypes& copy) = delete;
+
+		std::string			get_mime_type(const std::string& file_path);
+};
+
+#endif /*MIMETYPES_HPP*/

--- a/server/Request.cpp
+++ b/server/Request.cpp
@@ -65,8 +65,6 @@ Request&	Request::operator=(const Request &copy)
 
 int		Request::read_chunk(std::vector<char> buffer, int bytes_read)
 {
-	//! Make the main loop check if the content_len variable is bigger than the allowed one for that server, in that case we would send an error
-	//! basically if this function returns something that isnt 0 or 1 send an error to the client
 	if (_finished_reading == true)
 		return (0);
 	if (bytes_read < 0)
@@ -213,9 +211,9 @@ int	Request::process_post(void)
 	}
 	else
 	{
-		//! Replace the unknown filename with something like unknow.fileending or random.fileending, getting the ending from the mimetype map that is currently in the server class
+		std::string	file_extention = MimeTypes::getInstance().get_file_extension(con_type);
 		std::string body_str(_accumulated_request.begin(), _accumulated_request.end());
-		_post_files["unknown"] = body_str;
+		_post_files["unknown" + file_extention] = body_str;
 	}
 	return (0);
 }

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -13,9 +13,9 @@
  * @param data_dir the directory to POST/DELETE from (might be replaced by a redirect map in the future)
  * @param www_dir the location of the webpage files 
  * @param directory_listing_enabled true or false if the directory listing should be enabled
- * @param keepalive_timeout 
- * @param send_timeout 
- * @param max_body_size 
+ * @param keepalive_timeout Keepalive timeout in seconds, 0 to disable
+ * @param send_timeout Send timeout in seconds, 0 to disable
+ * @param max_body_size Max Body size the Server will read (the server may send bigger responses to the client), 0 to diable
  */
 Server::Server(const std::string server_name, int port, const std::string ip_address, const std::string index_file,
 		const std::string data_dir, const std::string www_dir, bool directory_listing_enabled, size_t keepalive_timeout,

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -25,7 +25,6 @@ Server::Server(const std::string server_name, int port, const std::string ip_add
 	_send_timeout(send_timeout), _max_body_size(max_body_size)
 {
 	Logger::getInstance().log(server_name, "Constructor called", 2);
-	load_mime_types("mime_type.csv");
 	_fd_server = socket(AF_INET, SOCK_STREAM, 0);
 	if (_fd_server == -1)
 		throw SocketCreationFailedException(_name);
@@ -120,20 +119,6 @@ std::string	Server::map_to_directory(const std::string& file_path)
 		return (_www_dir + file_path);
 }
 
-std::string	Server::get_mime_type(const std::string& file_path)
-{
-	std::string	file_extension = file_path.substr(file_path.find_last_of('.'));
-	try
-	{
-		return (_mime_types.at(file_extension));
-	}
-	catch (const std::out_of_range& e)
-	{
-		Logger::getInstance().log(_name, file_path + " has unknown MIME Type", 3);
-		return ("unknown/unknown");
-	}
-}
-
 std::string	Server::read_file(const std::string& file_path)
 {
 	std::ifstream		file(file_path);
@@ -141,24 +126,6 @@ std::string	Server::read_file(const std::string& file_path)
 
 	buffer << file.rdbuf();
 	return (buffer.str());
-}
-
-void	Server::load_mime_types(const std::string& file_path)
-{
-	std::ifstream file(file_path);
-	if (!file.is_open())
-		throw OpenFailedException(_name, file_path);
-	std::string	line;
-	while(std::getline(file, line))
-	{
-		std::istringstream	ss(line);
-		std::string			extension;
-		std::string			mime_type;
-
-		if (std::getline(ss, extension, '\t') && std::getline(ss, mime_type))
-			_mime_types[extension] = mime_type;
-	}
-	file.close();
 }
 
 std::string	Server::process_request(const Request& req)
@@ -216,7 +183,7 @@ std::string	Server::process_get(const Request& req)
 	else if (std::filesystem::exists(file_path))
 	{
 		std::string	file_content = read_file(file_path);
-		std::string	mime_type = get_mime_type(file_path);
+		std::string	mime_type = MimeTypes::getInstance().get_mime_type(file_path);
 		response += "Content-Type: " + mime_type + "\r\n";
 		std::string	con_len_str = std::to_string(file_content.size());
 		response += "Content-Length: " + con_len_str + "\r\n";
@@ -237,9 +204,6 @@ std::string	Server::process_delete(const Request& req)
 	{
 		if (std::remove(file_path.c_str()) == 0)
 		{
-			// std::string	response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n";
-			// if (send(req.get_fd(), response.c_str(), response.size(), 0) == -1)
-			// 	throw SendFailedException(_name, req.get_fd());
 			return (send_error_message(200));
 		}
 		else
@@ -284,7 +248,7 @@ std::string	Server::send_error_message(int error_code)
 	if (std::filesystem::exists(file_path))
 	{
 		std::string	file_content = read_file(file_path);
-		std::string	mime_type = get_mime_type(file_path);
+		std::string	mime_type = MimeTypes::getInstance().get_mime_type(file_path);
 		std::string	response = "HTTP/1.1 " + std::to_string(error_code) + " Error\r\n";
 		response += "Content-Type: " + mime_type + "\r\n";
 		std::string	con_len_str = std::to_string(file_content.size());

--- a/server/Server.hpp
+++ b/server/Server.hpp
@@ -21,13 +21,11 @@ class Server
 		std::string			_CLF_line;
 		std::unordered_map<std::string, std::string> _mime_types;
 
-		void				load_mime_types(const std::string& file_path);
 		std::string			process_get(const Request& req);
 		std::string			process_delete(const Request& req);
 		std::string			process_post(const Request& req);
 		std::string			extract_get_request(const std::string& request);
 		std::string			map_to_directory(const std::string& file_path);
-		std::string			get_mime_type(const std::string& file_path);
 		std::string			read_file(const std::string& file_path);
 	public:
 		Server(const std::string server_name, int port, const std::string ip_address, const std::string index_file,

--- a/server/SocketManager.hpp
+++ b/server/SocketManager.hpp
@@ -18,6 +18,7 @@ class SocketManager
 		std::unordered_map<int, std::string>				_response_map; // Tracking responses by client_fd
 		std::unordered_map<int, std::unique_ptr<Server>>	_server_map; // Tracking servers by port
 		std::vector<pollfd>									_fds;
+		std::vector<int>									_disconnect_after_send;
 
 		void	handle_read(int client_fd);
 		void	handle_write(int client_fd);
@@ -26,7 +27,7 @@ class SocketManager
 	public:
 		SocketManager();
 		~SocketManager();
-		//temp, replace once config parser is merged
+
 		void	add_server(int port, std::unique_ptr<Server> server);
 		void	add_client(int client_fd);
 		void	remove_client(int client_fd);

--- a/webserv.h
+++ b/webserv.h
@@ -34,6 +34,7 @@
 # include "utils/utils.h"
 # include "parser/parsing/parse_config_file.hpp"
 # include "log/Logger.hpp"
+# include "MimeTypes.hpp"
 
 // some output formatting macros:
 # define BOLD(text) "\033[1m" << text << "\033[0m"

--- a/webserv.h
+++ b/webserv.h
@@ -34,7 +34,7 @@
 # include "utils/utils.h"
 # include "parser/parsing/parse_config_file.hpp"
 # include "log/Logger.hpp"
-# include "MimeTypes.hpp"
+# include "server/MimeTypes.hpp"
 
 // some output formatting macros:
 # define BOLD(text) "\033[1m" << text << "\033[0m"


### PR DESCRIPTION
Made a singleton class for MimeTypes. I start that class in the begining to ensure exceptions are caught before any server is started.
Deleted the mime specific functions in server and replaced calls to get_mime_type with the MimeTypes own function.
Added a mimetypes function to get a file ending from a MimeType. Currently it is working with the existing map, should for whatever reason many files come without a filename, creating a second map storing fileendings relative to mimetypes might be more efficient (taking more space though)
If a POST file comes without a name, it will be now named unknown.fileending making sure it can be displayed correctly

FIXED Fatal issue: Requesting a file without any file extension, lead to a crash inside the get_mime_type function, has been fixed now.

Added a Vector<int> inside the SocketManager class. All members of this vector are fds marked for disconnect after sending is complete. A FD is added to this vector if the client sends a bad request (400) or a too large payload (413)
After sending is finished, the SocketManager will check if the clients fd is inside the fd, in which case the client will be disconnected isntead of staying alive. This fixes issues with an already full pipe.
We might want to change the reading to check for a valid method at the beginning, to ensure we dont read forever if the client sends 4TB of garbage without ever sending a valid HTTP header.